### PR TITLE
fix: add verification if resource has 'fetchRemote' permission

### DIFF
--- a/handler/update.lua
+++ b/handler/update.lua
@@ -2,6 +2,10 @@ local VERSION = 10
 
 addEventHandler( "onResourceStart", resourceRoot,
 	function ( )
+        if not hasObjectPermissionTo(getThisResource(), "resource."..getResourceName(getThisResource())..".fetchRemote", false ) then
+           outputDebugString("This resource needs permission to 'fetchRemote' for update automatically", 2)
+           return
+        end
         fetchRemote("https://api.github.com/repos/clawsuit/dxLibrary/releases/latest", 
         	function(data, status)
            		assert(status == 0 and data, resource.name..": Can't fetch 'api.github.com' for new releases! ( Status code: "..tostring(status).." ) " )


### PR DESCRIPTION
This commit change the following message:
![image](https://user-images.githubusercontent.com/65371964/236353103-d394e39b-0d9a-4c05-b599-b5535193ace6.png)
to this custom message:
![image](https://user-images.githubusercontent.com/65371964/236353175-612162be-3e2a-4988-b07c-b8cdbe1672cd.png)
This message explains to the user why this resource needs fetchRemote permission